### PR TITLE
No longer need github token for asdf-vm/actions/plugin-test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,8 +20,6 @@ jobs:
     - uses: asdf-vm/actions/plugin-test@v1
       with:
         command: getenvoy --version
-      env:
-        GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
asdf-vm/actions/plugin-test set github token automatically since v1.1.0.